### PR TITLE
CA: Fixing typos in JavaDoc and comments

### DIFF
--- a/java/common/src/main/java/org/commongeoregistry/adapter/RegistryAdapterRemote.java
+++ b/java/common/src/main/java/org/commongeoregistry/adapter/RegistryAdapterRemote.java
@@ -54,7 +54,7 @@ public class RegistryAdapterRemote extends RegistryAdapter
   /**
    * 
    * 
-   * @param _cgrURL URL to the ommon geo-registry
+   * @param _cgrURL URL to the common geo-registry
    */
   public RegistryAdapterRemote(String _cgrURL)
   {

--- a/java/common/src/main/java/org/commongeoregistry/adapter/metadata/GeoObjectType.java
+++ b/java/common/src/main/java/org/commongeoregistry/adapter/metadata/GeoObjectType.java
@@ -132,7 +132,7 @@ public class GeoObjectType implements Serializable
   
 
   /**
-   * Returns the unique identifier that his human readable.
+   * Returns the code which is the human readable unique identifier.
    * 
    * @return Code value.
    */
@@ -178,7 +178,7 @@ public class GeoObjectType implements Serializable
    * 
    * @pre Attribute with the given name is defined on this {@link GeoObjectType}.
    * 
-   * @return Name of the attribute.s
+   * @return Name of the attributes.
    */
   public Optional<AttributeType> getAttribute(String _name)
   {

--- a/java/common/src/main/java/org/commongeoregistry/adapter/metadata/HierarchyType.java
+++ b/java/common/src/main/java/org/commongeoregistry/adapter/metadata/HierarchyType.java
@@ -139,7 +139,7 @@ public class HierarchyType implements Serializable
     }
     
     /**
-     * Returns the child nodes of this current node..
+     * Returns the child nodes of this current node.
      * 
      * @return child nodes of this current node.
      */
@@ -174,7 +174,7 @@ public class HierarchyType implements Serializable
     
     /**
      * Generates JSON for the Hierarchy Node.
-     * s
+     * 
      * @param sJson
      * @param registry
      * @return JSON for the Hierarchy Node.

--- a/java/remote/src/main/java/org/commongeoregistry/adapter/android/RegistryAdapterAndroid.java
+++ b/java/remote/src/main/java/org/commongeoregistry/adapter/android/RegistryAdapterAndroid.java
@@ -15,7 +15,7 @@ public class RegistryAdapterAndroid extends RegistryAdapterRemote
   /**
    * 
    * 
-   * @param _cgrURL URL to the ommon geo-registry
+   * @param _cgrURL URL to the common geo-registry
    */
   public RegistryAdapterAndroid(String _cgrURL)
   {


### PR DESCRIPTION
I found some typos in the JavaDoc while reviewing the code and wanted to fix them.